### PR TITLE
Support reconstruction and reload

### DIFF
--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -86,9 +86,9 @@ public:
 
 	// construction
 	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass);
+	void construct(iterator begin, iterator end, bool two_pass = true);
 	template<random_access_container container>
-	void construct(const container& texts, bool two_pass);
+	void construct(const container& texts, bool two_pass = true);
 
 	// search operations
 	bool exists(const text& pattern) const;

--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -123,10 +123,9 @@ protected:
 
 	void reset(integer node_count = static_cast<integer>(0), integer label_count = static_cast<integer>(0));
 	template<typename iterator>
-	std::pair<integer, integer> estimate(iterator begin, iterator end);
+	std::pair<integer, integer> estimate(iterator begin, iterator end) const;
 	template<typename iterator>
-	std::pair<integer, integer> estimate(iterator begin, iterator end, integer depth);
-
+	std::pair<integer, integer> estimate(iterator begin, iterator end, integer depth) const;
 	template<typename iterator>
 	void construct(iterator begin, iterator end, integer depth, integer current);
 };
@@ -417,16 +416,15 @@ void map_compact<text, item, integer>::reset(integer node_count, integer label_c
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator begin, iterator end)
+std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator begin, iterator end) const
 {
 	auto [node_count, label_count] = estimate(begin, end, 0);
-	reset(node_count + 1, label_count);
 	return {node_count + 1, label_count};
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator begin, iterator end, integer depth)
+std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator begin, iterator end, integer depth) const
 {
 	integer node_count = 1, label_count = 0;
 
@@ -456,10 +454,13 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 integer map_compact<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	if(two_pass)
-		estimate(begin, end);
-	else
+	if(two_pass){
+		auto [node_count, label_count] = estimate(begin, end);
+		reset(node_count, label_count);
+	}
+	else{
 		reset();
+	}
 
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)

--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -62,11 +62,10 @@ public:
 
 	using node_type = virtual_node;
 
+public:
 	// constructors
-protected:
 	map_compact(
 		integer min_binary_search = static_cast<integer>(constants::default_min_binary_search<symbol>()));
-public:
 	template<std::random_access_iterator iterator>
 	map_compact(iterator begin, iterator end, bool two_pass = true,
 		integer min_binary_search = static_cast<integer>(constants::default_min_binary_search<symbol>()));

--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -420,6 +420,7 @@ template<typename iterator>
 std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator begin, iterator end)
 {
 	auto [node_count, label_count] = estimate(begin, end, 0);
+	reset(node_count + 1, label_count);
 	return {node_count + 1, label_count};
 }
 
@@ -455,13 +456,10 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 integer map_compact<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	if(two_pass){
-		auto [node_count, label_count] = estimate(begin, end);
-		reset(node_count, label_count);
-	}
-	else{
+	if(two_pass)
+		estimate(begin, end);
+	else
 		reset();
-	}
 
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)

--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -84,6 +84,12 @@ public:
 	size_type trie_size() const;
 	size_type total_space() const;
 
+	// construction
+	template<typename iterator>
+	void construct(iterator begin, iterator end, bool two_pass);
+	template<random_access_container container>
+	void construct(const container& texts, bool two_pass);
+
 	// search operations
 	bool exists(const text& pattern) const;
 	node_type find(const text& pattern) const;
@@ -120,8 +126,6 @@ protected:
 	template<typename iterator>
 	std::pair<integer, integer> estimate(iterator begin, iterator end, integer depth);
 
-	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass);
 	template<typename iterator>
 	void construct(iterator begin, iterator end, integer depth, integer current);
 };
@@ -435,21 +439,36 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 void map_compact<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
+	data.clear();
+	labels.clear();
+
 	if(two_pass){
 		auto [node_count, label_count] = estimate(begin, end);
 		data.reserve(node_count);
 		labels.reserve(label_count);
 	}
+
+	data.push_back({false, false, 1, 0, {}, {}});
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)
 			data[0].value = selector::value(*begin);
 		construct(begin, end, 0, 0);
 	}
 	data.push_back({false, false, container_size(data), container_size(labels), {}, {}});
+
 	if(!two_pass){
 		data.shrink_to_fit();
 		labels.shrink_to_fit();
 	}
+
+	num_texts = end - begin;
+}
+
+template<lexicographically_comparable text, default_constructible item, std::integral integer>
+template<random_access_container container>
+void map_compact<text, item, integer>::construct(const container& texts, bool two_pass)
+{
+	construct(std::begin(texts), std::end(texts), two_pass);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>

--- a/include/sftrie/map_compact.hpp
+++ b/include/sftrie/map_compact.hpp
@@ -86,9 +86,9 @@ public:
 
 	// construction
 	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass = true);
+	integer construct(iterator begin, iterator end, bool two_pass = true);
 	template<random_access_container container>
-	void construct(const container& texts, bool two_pass = true);
+	integer construct(const container& texts, bool two_pass = true);
 
 	// search operations
 	bool exists(const text& pattern) const;
@@ -453,7 +453,7 @@ std::pair<integer, integer> map_compact<text, item, integer>::estimate(iterator 
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-void map_compact<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
+integer map_compact<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
 	if(two_pass){
 		auto [node_count, label_count] = estimate(begin, end);
@@ -475,14 +475,14 @@ void map_compact<text, item, integer>::construct(iterator begin, iterator end, b
 		labels.shrink_to_fit();
 	}
 
-	num_texts = end - begin;
+	return (num_texts = end - begin);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<random_access_container container>
-void map_compact<text, item, integer>::construct(const container& texts, bool two_pass)
+integer map_compact<text, item, integer>::construct(const container& texts, bool two_pass)
 {
-	construct(std::begin(texts), std::end(texts), two_pass);
+	return construct(std::begin(texts), std::end(texts), two_pass);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -86,9 +86,9 @@ public:
 
 	// construction
 	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass);
+	void construct(iterator begin, iterator end, bool two_pass = true);
 	template<random_access_container container>
-	void construct(const container& texts, bool two_pass);
+	void construct(const container& texts, bool two_pass = true);
 
 	// search operations
 	bool exists(const text& pattern) const;
@@ -405,8 +405,7 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 void map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	if(two_pass)
-		reset(two_pass ? estimate(begin, end) : 0);
+	reset(two_pass ? estimate(begin, end) : 0);
 
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -84,6 +84,12 @@ public:
 	size_type trie_size() const;
 	size_type total_space() const;
 
+	// construction
+	template<typename iterator>
+	void construct(iterator begin, iterator end, bool two_pass);
+	template<random_access_container container>
+	void construct(const container& texts, bool two_pass);
+
 	// search operations
 	bool exists(const text& pattern) const;
 	node_type find(const text& pattern) const;
@@ -117,9 +123,6 @@ protected:
 	integer estimate(iterator begin, iterator end);
 	template<typename iterator>
 	integer estimate(iterator begin, iterator end, integer depth);
-
-	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass);
 	template<typename iterator>
 	void construct(iterator begin, iterator end, integer depth, integer current);
 
@@ -390,16 +393,30 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 void map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
+	data.clear();
+
 	if(two_pass)
 		data.reserve(estimate(begin, end));
+
+	data.push_back({false, false, 1, {}, {}});
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)
 			data[0].value = selector::value(*begin);
 		construct(begin, end, 0, 0);
 	}
 	data.push_back({false, false, container_size(data), {}, {}});
+
 	if(!two_pass)
 		data.shrink_to_fit();
+
+	num_texts = end - begin;
+}
+
+template<lexicographically_comparable text, default_constructible item, std::integral integer>
+template<random_access_container container>
+void map_original<text, item, integer>::construct(const container& texts, bool two_pass)
+{
+	construct(std::begin(texts), std::end(texts), two_pass);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -121,9 +121,9 @@ protected:
 
 	void reset(integer node_count = static_cast<integer>(0));
 	template<typename iterator>
-	integer estimate(iterator begin, iterator end);
+	integer estimate(iterator begin, iterator end) const;
 	template<typename iterator>
-	integer estimate(iterator begin, iterator end, integer depth);
+	integer estimate(iterator begin, iterator end, integer depth) const;
 	template<typename iterator>
 	void construct(iterator begin, iterator end, integer depth, integer current);
 
@@ -377,16 +377,14 @@ void map_original<text, item, integer>::reset(integer node_count)
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-integer map_original<text, item, integer>::estimate(iterator begin, iterator end)
+integer map_original<text, item, integer>::estimate(iterator begin, iterator end) const
 {
-	integer node_count = estimate(begin, end, 0);
-	reset(node_count + 1); // sentinel
-	return node_count + 1;
+	return estimate(begin, end, 0) + 1; // sentinel
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-integer map_original<text, item, integer>::estimate(iterator begin, iterator end, integer depth)
+integer map_original<text, item, integer>::estimate(iterator begin, iterator end, integer depth) const
 {
 	integer node_count = 1;
 
@@ -406,10 +404,7 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 integer map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	if(two_pass)
-		estimate(begin, end);
-	else
-		reset();
+	reset(two_pass ? estimate(begin, end) : 0);
 
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -379,15 +379,16 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 integer map_original<text, item, integer>::estimate(iterator begin, iterator end)
 {
-	integer count = estimate(begin, end, 0);
-	return count + 1; // sentinel
+	integer node_count = estimate(begin, end, 0);
+	reset(node_count + 1); // sentinel
+	return node_count + 1;
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
 integer map_original<text, item, integer>::estimate(iterator begin, iterator end, integer depth)
 {
-	integer count = 1;
+	integer node_count = 1;
 
 	if(begin < end && depth == container_size(selector::key(*begin)))
 		++begin;
@@ -395,17 +396,20 @@ integer map_original<text, item, integer>::estimate(iterator begin, iterator end
 	for(iterator i = begin; i < end; begin = i){
 		for(symbol c = selector::key(*i)[depth];
 			i < end && selector::key(*i)[depth] == c; ++i);
-		count += estimate(begin, i, depth + 1);
+		node_count += estimate(begin, i, depth + 1);
 	}
 
-	return count;
+	return node_count;
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
 integer map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	reset(two_pass ? estimate(begin, end) : 0);
+	if(two_pass)
+		estimate(begin, end);
+	else
+		reset();
 
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -119,6 +119,7 @@ protected:
 	template<typename container>
 	static integer container_size(const container& c);
 
+	void reset(integer node_count = static_cast<integer>(0));
 	template<typename iterator>
 	integer estimate(iterator begin, iterator end);
 	template<typename iterator>
@@ -337,6 +338,8 @@ integer map_original<text, item, integer>::load(input_stream& is)
 	if(header.label_count != 0)
 		throw std::runtime_error("invalid label count");
 
+	reset(header.node_count);
+
 	data.resize(header.node_count);
 	is.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(sizeof(node) * header.node_count));
 
@@ -361,6 +364,15 @@ typename map_original<text, item, integer>::integer_type
 map_original<text, item, integer>::container_size(const container& c)
 {
 	return static_cast<integer>(c.size());
+}
+
+template<lexicographically_comparable text, default_constructible item, std::integral integer>
+void map_original<text, item, integer>::reset(integer node_count)
+{
+	data.clear();
+	if(node_count != 0)
+		data.reserve(node_count);
+	data.push_back({false, false, 1, {}, {}});
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
@@ -393,12 +405,9 @@ template<lexicographically_comparable text, default_constructible item, std::int
 template<typename iterator>
 void map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
-	data.clear();
-
 	if(two_pass)
-		data.reserve(estimate(begin, end));
+		reset(two_pass ? estimate(begin, end) : 0);
 
-	data.push_back({false, false, 1, {}, {}});
 	if(begin < end){
 		if(selector::key(*begin).size() == 0)
 			data[0].value = selector::value(*begin);

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -86,9 +86,9 @@ public:
 
 	// construction
 	template<typename iterator>
-	void construct(iterator begin, iterator end, bool two_pass = true);
+	integer construct(iterator begin, iterator end, bool two_pass = true);
 	template<random_access_container container>
-	void construct(const container& texts, bool two_pass = true);
+	integer construct(const container& texts, bool two_pass = true);
 
 	// search operations
 	bool exists(const text& pattern) const;
@@ -403,7 +403,7 @@ integer map_original<text, item, integer>::estimate(iterator begin, iterator end
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<typename iterator>
-void map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
+integer map_original<text, item, integer>::construct(iterator begin, iterator end, bool two_pass)
 {
 	reset(two_pass ? estimate(begin, end) : 0);
 
@@ -417,14 +417,14 @@ void map_original<text, item, integer>::construct(iterator begin, iterator end, 
 	if(!two_pass)
 		data.shrink_to_fit();
 
-	num_texts = end - begin;
+	return (num_texts = end - begin);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>
 template<random_access_container container>
-void map_original<text, item, integer>::construct(const container& texts, bool two_pass)
+integer map_original<text, item, integer>::construct(const container& texts, bool two_pass)
 {
-	construct(std::begin(texts), std::end(texts), two_pass);
+	return construct(std::begin(texts), std::end(texts), two_pass);
 }
 
 template<lexicographically_comparable text, default_constructible item, std::integral integer>

--- a/include/sftrie/map_original.hpp
+++ b/include/sftrie/map_original.hpp
@@ -62,11 +62,10 @@ public:
 
 	using node_type = virtual_node;
 
+public:
 	// constructors
-protected:
 	map_original(
 		integer min_binary_search = static_cast<integer>(constants::default_min_binary_search<symbol>()));
-public:
 	template<std::random_access_iterator iterator>
 	map_original(iterator begin, iterator end, bool two_pass = true,
 		integer min_binary_search = static_cast<integer>(constants::default_min_binary_search<symbol>()));

--- a/test/construction.cpp
+++ b/test/construction.cpp
@@ -65,7 +65,6 @@ void test_set_construction(
 			CHECK(index.exists(pattern));
 	}
 
-/*
 	SECTION("reconstruction"){
 		index.construct(texts, two_pass);
 		CHECK(index.size() == texts.size());
@@ -77,7 +76,6 @@ void test_set_construction(
 		for(const auto& pattern: texts)
 			CHECK(index.exists(pattern));
 	}
-*/
 }
 
 template<typename text, typename integer>
@@ -159,7 +157,6 @@ void test_map_construction(
 			CHECK(index[pattern] == expected_value);
 	}
 
-/*
 	SECTION("reconstruction"){
 		index.construct(texts, two_pass);
 		CHECK(index.size() == texts.size());
@@ -171,7 +168,6 @@ void test_map_construction(
 		for(const auto& [pattern, expected_value]: texts)
 			CHECK(index[pattern] == expected_value);
 	}
-*/
 }
 
 template<typename text, typename integer>

--- a/test/construction.cpp
+++ b/test/construction.cpp
@@ -66,8 +66,7 @@ void test_set_construction(
 	}
 
 	SECTION("reconstruction"){
-		index.construct(texts, two_pass);
-		CHECK(index.size() == texts.size());
+		CHECK(index.construct(texts, two_pass) == texts.size());
 		CHECK(index.node_size() == sizeof(typename set::node));
 		if(expected_sizes[0] > 0)
 			CHECK(index.trie_size() == expected_sizes[0]);
@@ -158,8 +157,7 @@ void test_map_construction(
 	}
 
 	SECTION("reconstruction"){
-		index.construct(texts, two_pass);
-		CHECK(index.size() == texts.size());
+		CHECK(index.construct(texts, two_pass) == texts.size());
 		CHECK(index.node_size() == sizeof(typename map::node));
 		if(expected_sizes[0] > 0)
 			CHECK(index.trie_size() == expected_sizes[0]);

--- a/test/construction.cpp
+++ b/test/construction.cpp
@@ -64,6 +64,20 @@ void test_set_construction(
 		for(const auto& pattern: texts)
 			CHECK(index.exists(pattern));
 	}
+
+/*
+	SECTION("reconstruction"){
+		index.construct(texts, two_pass);
+		CHECK(index.size() == texts.size());
+		CHECK(index.node_size() == sizeof(typename set::node));
+		if(expected_sizes[0] > 0)
+			CHECK(index.trie_size() == expected_sizes[0]);
+		if(expected_sizes[1] > 0)
+			CHECK(index.total_space() == expected_sizes[1]);
+		for(const auto& pattern: texts)
+			CHECK(index.exists(pattern));
+	}
+*/
 }
 
 template<typename text, typename integer>
@@ -144,6 +158,20 @@ void test_map_construction(
 		for(const auto& [pattern, expected_value]: texts)
 			CHECK(index[pattern] == expected_value);
 	}
+
+/*
+	SECTION("reconstruction"){
+		index.construct(texts, two_pass);
+		CHECK(index.size() == texts.size());
+		CHECK(index.node_size() == sizeof(typename map::node));
+		if(expected_sizes[0] > 0)
+			CHECK(index.trie_size() == expected_sizes[0]);
+		if(expected_sizes[1] > 0)
+			CHECK(index.total_space() == expected_sizes[1]);
+		for(const auto& [pattern, expected_value]: texts)
+			CHECK(index[pattern] == expected_value);
+	}
+*/
 }
 
 template<typename text, typename integer>

--- a/test/save_load.cpp
+++ b/test/save_load.cpp
@@ -56,6 +56,12 @@ void test_set_save_load(
 		for(const auto& pattern: texts)
 			CHECK(index1.exists(pattern));
 	}
+
+	SECTION("reload"){
+		ss.seekg(0);
+		index0.load(ss);
+		CHECK(index0.trie_size() == expected_size);
+	}
 }
 
 template<typename text>
@@ -118,6 +124,12 @@ void test_map_save_load(
 	SECTION("search patterns in texts"){
 		for(const auto& [pattern, expected_value]: texts)
 			CHECK(index1[pattern] == expected_value);
+	}
+
+	SECTION("reload"){
+		ss.seekg(0);
+		index0.load(ss);
+		CHECK(index0.trie_size() == expected_size);
 	}
 }
 


### PR DESCRIPTION
- make `construct()` and default constructors public
- fix bugs in reloading indices from files